### PR TITLE
Fix js link ordering

### DIFF
--- a/index.html
+++ b/index.html
@@ -65,9 +65,8 @@
     </div>
   </body>
 
-  <script type="text/javascript" src="js/main.js"></script>
-  <script type="text/javascript" src="js/bootstrap.js"></script>
   <script type="text/javascript" src="js/jquery-2.1.4.js"></script>
+  <script type="text/javascript" src="js/bootstrap.js"></script>
   <script type="text/javascript" src="js/npm.js"></script>
   <script type="text/javascript" src="js/main.js"></script>
 </html>


### PR DESCRIPTION
bootstrap.js depends on jquery, so jquery must be linked first.

This is why the navbar-collapse doesn't work.
Closes #2